### PR TITLE
Feature/start migrations synchronous

### DIFF
--- a/IssueTrackerAPI/Program.cs
+++ b/IssueTrackerAPI/Program.cs
@@ -60,18 +60,7 @@ builder.Services.SetUpFluentMigration(builder.Configuration.GetConnectionString(
 
 var app = builder.Build();
 
-using var scope = app.Services.CreateScope();
-var migratorRunner = scope.ServiceProvider.GetService<IMigrationRunner>();
-
-try
-{
-    migratorRunner.MigrateUp();
-}
-catch (Exception ex)
-{
-    Console.WriteLine($"Migration failed with exception: {ex.Message}");
-    return;
-}
+app.Services.StartMigrations();
 
 // Configure the HTTP request pipeline.
 if (app.Environment.IsDevelopment())

--- a/IssueTrackerAPI/Program.cs
+++ b/IssueTrackerAPI/Program.cs
@@ -55,7 +55,13 @@ builder.Services.AddAutoMapper(typeof(AutoMapperProfile))
     .AddScoped<IRepository<Project>, Repository<Project>>()
     .AddScoped<IRepository<User>, Repository<User>>();
 
-builder.Services.AddHostedService<MigrationService>();
+var migrationSuccessful = builder.Services.StartMigration(builder.Configuration.GetConnectionString("SqlServer"));
+
+if(!migrationSuccessful)
+{
+    // We will do something different in case Migrations fail, this is just temporary :)
+    return;
+}
 
 var app = builder.Build();
 

--- a/IssueTrackerApplication/Services/MigrationService.cs
+++ b/IssueTrackerApplication/Services/MigrationService.cs
@@ -9,31 +9,16 @@ namespace IssueTracker.Application.Services
 {
     public static class MigrationService
     {
-        public static bool StartMigration(this IServiceCollection services, string connectionString)
+        public static IServiceCollection SetUpFluentMigration(this IServiceCollection services, string connectionString)
         {
-            var serviceProvider = services.AddFluentMigratorCore()
-            .ConfigureRunner(config => config
-            .AddSqlServer()
-            .WithGlobalConnectionString(connectionString)
-            .ScanIn(typeof(IssueTracker.DataAccess.Migrations.AddRoleColumnToUsersTable).Assembly).For.All())
-            .AddLogging(config => config.AddFluentMigratorConsole())
-            .BuildServiceProvider(false);
+            services.AddFluentMigratorCore()
+                .ConfigureRunner(config => config
+                    .AddSqlServer()
+                    .WithGlobalConnectionString(connectionString)
+                    .ScanIn(typeof(IssueTracker.DataAccess.Migrations.AddRoleColumnToUsersTable).Assembly).For.All())
+                .AddLogging(config => config.AddFluentMigratorConsole());
 
-            using (var scope = serviceProvider.CreateScope())
-            {
-                try
-                {
-                    var runner = scope.ServiceProvider.GetRequiredService<IMigrationRunner>();
-                    runner.MigrateUp();
-                }
-                catch (Exception ex)
-                {
-                    // Migration Failed
-                    return false;
-                }
-            }
-
-            return true;
+            return services;
         }
     }
 }

--- a/IssueTrackerApplication/Services/MigrationService.cs
+++ b/IssueTrackerApplication/Services/MigrationService.cs
@@ -30,6 +30,7 @@ namespace IssueTracker.Application.Services
             catch (Exception ex)
             {
                 Console.WriteLine($"Migration failed with exception: {ex.Message}");
+                throw;
             }
 
             return provider;

--- a/IssueTrackerApplication/Services/MigrationService.cs
+++ b/IssueTrackerApplication/Services/MigrationService.cs
@@ -1,9 +1,5 @@
 ﻿using FluentMigrator.Runner;
-using IssueTracker.DataAccess;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
-using System.Reflection;
-using static Microsoft.EntityFrameworkCore.DbLoggerCategory;
 
 namespace IssueTracker.Application.Services
 {
@@ -19,6 +15,24 @@ namespace IssueTracker.Application.Services
                 .AddLogging(config => config.AddFluentMigratorConsole());
 
             return services;
+        }
+
+        public static IServiceProvider StartMigrations(this IServiceProvider provider)
+        {
+            using var scope = provider.CreateScope();
+
+            var migratorRunner = scope.ServiceProvider.GetService<IMigrationRunner>();
+
+            try
+            {
+                migratorRunner.MigrateUp();
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Migration failed with exception: {ex.Message}");
+            }
+
+            return provider;
         }
     }
 }

--- a/IssueTrackerDataAccess/DataAccessExtensions.cs
+++ b/IssueTrackerDataAccess/DataAccessExtensions.cs
@@ -12,13 +12,6 @@ namespace IssueTracker.DataAccess
             services.AddDbContext<IssueContext>(
                 o => o.UseSqlServer(connectionString));
 
-            services.AddFluentMigratorCore()
-            .ConfigureRunner(config => config
-            .AddSqlServer()
-            .WithGlobalConnectionString(connectionString)
-            .ScanIn(typeof(Migrations.AddRoleColumnToUsersTable).Assembly).For.All())
-            .AddLogging(config => config.AddFluentMigratorConsole());
-
             return services;
         }
     }


### PR DESCRIPTION
Start Migrations synchronous before app start. Also check if migrations are run successfully or not. If they fail we don't start the app, will change it later.
Also, small change : Modified 'Token' to 'Secret' in appsettings.json and forgot to change it in Program.cs when adding Jwt Bearer.